### PR TITLE
Add date/time facts for display in instrument widget

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -219,6 +219,7 @@
         <file alias="Vehicle/TemperatureFact.json">src/Vehicle/TemperatureFact.json</file>
         <file alias="Vehicle/SubmarineFact.json">src/Vehicle/SubmarineFact.json</file>
         <file alias="Vehicle/ArduSubVehicleFact.json">src/Vehicle/ArduSubVehicleFact.json</file>
+        <file alias="Vehicle/ClockFact.json">src/Vehicle/ClockFact.json</file>
     </qresource>
     <qresource prefix="/MockLink">
         <file alias="APMArduCopterMockLink.params">src/comm/APMArduCopterMockLink.params</file>

--- a/src/FactSystem/FactGroup.h
+++ b/src/FactSystem/FactGroup.h
@@ -46,8 +46,8 @@ protected:
 
     int _updateRateMSecs;   ///< Update rate for Fact::valueChanged signals, 0: immediate update
 
-private slots:
-    void _updateAllValues(void);
+protected slots:
+    virtual void _updateAllValues(void);
 
 private:
     void _loadMetaData(const QString& filename);

--- a/src/Vehicle/ClockFact.json
+++ b/src/Vehicle/ClockFact.json
@@ -1,0 +1,12 @@
+[
+{
+    "name":             "currentTime",
+    "shortDescription": "Time",
+    "type":             "string"
+},
+{
+    "name":             "currentDate",
+    "shortDescription": "Date",
+    "type":             "string"
+}
+]

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -7,6 +7,9 @@
  *
  ****************************************************************************/
 
+#include <QTime>
+#include <QDateTime>
+#include <QLocale>
 
 #include "Vehicle.h"
 #include "MAVLinkProtocol.h"
@@ -59,6 +62,7 @@ const char* Vehicle::_batteryFactGroupName =    "battery";
 const char* Vehicle::_windFactGroupName =       "wind";
 const char* Vehicle::_vibrationFactGroupName =  "vibration";
 const char* Vehicle::_temperatureFactGroupName = "temperature";
+const char* Vehicle::_clockFactGroupName =      "clock";
 
 Vehicle::Vehicle(LinkInterface*             link,
                  int                        vehicleId,
@@ -161,6 +165,7 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _windFactGroup(this)
     , _vibrationFactGroup(this)
     , _temperatureFactGroup(this)
+    , _clockFactGroup(this)
 {
     _addLink(link);
 
@@ -318,6 +323,7 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
     , _batteryFactGroup(this)
     , _windFactGroup(this)
     , _vibrationFactGroup(this)
+    , _clockFactGroup(this)
 {
     _commonInit();
     _firmwarePlugin->initializeVehicle(this);
@@ -371,6 +377,7 @@ void Vehicle::_commonInit(void)
     _addFactGroup(&_windFactGroup,      _windFactGroupName);
     _addFactGroup(&_vibrationFactGroup, _vibrationFactGroupName);
     _addFactGroup(&_temperatureFactGroup, _temperatureFactGroupName);
+    _addFactGroup(&_clockFactGroup,     _clockFactGroupName);
 
     // Add firmware-specific fact groups, if provided
     QMap<QString, FactGroup*>* fwFactGroups = _firmwarePlugin->factGroups();
@@ -2750,4 +2757,28 @@ VehicleTemperatureFactGroup::VehicleTemperatureFactGroup(QObject* parent)
     _temperature1Fact.setRawValue      (std::numeric_limits<float>::quiet_NaN());
     _temperature2Fact.setRawValue      (std::numeric_limits<float>::quiet_NaN());
     _temperature3Fact.setRawValue      (std::numeric_limits<float>::quiet_NaN());
+}
+
+const char* VehicleClockFactGroup::_currentTimeFactName = "currentTime";
+const char* VehicleClockFactGroup::_currentDateFactName = "currentDate";
+
+VehicleClockFactGroup::VehicleClockFactGroup(QObject* parent)
+    : FactGroup(1000, ":/json/Vehicle/ClockFact.json", parent)
+    , _currentTimeFact  (0, _currentTimeFactName,    FactMetaData::valueTypeString)
+    , _currentDateFact  (0, _currentDateFactName,    FactMetaData::valueTypeString)
+{
+    _addFact(&_currentTimeFact, _currentTimeFactName);
+    _addFact(&_currentDateFact, _currentDateFactName);
+
+    // Start out as not available "--.--"
+    _currentTimeFact.setRawValue    (std::numeric_limits<float>::quiet_NaN());
+    _currentDateFact.setRawValue    (std::numeric_limits<float>::quiet_NaN());
+}
+
+void VehicleClockFactGroup::_updateAllValues(void)
+{
+    _currentTimeFact.setRawValue(QTime::currentTime().toString());
+    _currentDateFact.setRawValue(QDateTime::currentDateTime().toString(QLocale::system().dateFormat(QLocale::ShortFormat)));
+
+    FactGroup::_updateAllValues();
 }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -222,6 +222,32 @@ private:
     Fact            _temperature3Fact;
 };
 
+class VehicleClockFactGroup : public FactGroup
+{
+    Q_OBJECT
+
+public:
+    VehicleClockFactGroup(QObject* parent = NULL);
+
+    Q_PROPERTY(Fact* currentTime        READ currentTime        CONSTANT)
+    Q_PROPERTY(Fact* currentDate        READ currentDate        CONSTANT)
+
+    Fact* currentTime (void) { return &_currentTimeFact; }
+    Fact* currentDate (void) { return &_currentDateFact; }
+
+    static const char* _currentTimeFactName;
+    static const char* _currentDateFactName;
+
+    static const char* _settingsGroup;
+
+private slots:
+    void _updateAllValues(void) override;
+
+private:
+    Fact            _currentTimeFact;
+    Fact            _currentDateFact;
+};
+
 class Vehicle : public FactGroup
 {
     Q_OBJECT
@@ -357,6 +383,7 @@ public:
     Q_PROPERTY(FactGroup* wind        READ windFactGroup        CONSTANT)
     Q_PROPERTY(FactGroup* vibration   READ vibrationFactGroup   CONSTANT)
     Q_PROPERTY(FactGroup* temperature READ temperatureFactGroup CONSTANT)
+    Q_PROPERTY(FactGroup* clock       READ clockFactGroup       CONSTANT)
 
     Q_PROPERTY(int      firmwareMajorVersion        READ firmwareMajorVersion       NOTIFY firmwareVersionChanged)
     Q_PROPERTY(int      firmwareMinorVersion        READ firmwareMinorVersion       NOTIFY firmwareVersionChanged)
@@ -618,6 +645,7 @@ public:
     FactGroup* windFactGroup        (void) { return &_windFactGroup; }
     FactGroup* vibrationFactGroup   (void) { return &_vibrationFactGroup; }
     FactGroup* temperatureFactGroup (void) { return &_temperatureFactGroup; }
+    FactGroup* clockFactGroup       (void) { return &_clockFactGroup; }
 
     void setConnectionLostEnabled(bool connectionLostEnabled);
 
@@ -1030,6 +1058,7 @@ private:
     VehicleWindFactGroup        _windFactGroup;
     VehicleVibrationFactGroup   _vibrationFactGroup;
     VehicleTemperatureFactGroup _temperatureFactGroup;
+    VehicleClockFactGroup       _clockFactGroup;
 
     static const char* _rollFactName;
     static const char* _pitchFactName;
@@ -1047,6 +1076,7 @@ private:
     static const char* _windFactGroupName;
     static const char* _vibrationFactGroupName;
     static const char* _temperatureFactGroupName;
+    static const char* _clockFactGroupName;
 
     static const int _vehicleUIUpdateRateMSecs = 100;
 


### PR DESCRIPTION
This PR adds facts for displaying the current date and time in the instrument widget.  This allows users to include the date and time of recording in screen captures.

![screen shot 2017-10-03 at 2 43 39 pm](https://user-images.githubusercontent.com/10507633/31150886-362c8c8a-a84a-11e7-9ce7-8318274a1527.png)

The date and time facts are located in their own fact group for the purpose of organization.

![screen shot 2017-10-03 at 2 44 37 pm](https://user-images.githubusercontent.com/10507633/31150997-9f63ae9a-a84a-11e7-8f5e-620f60164543.png)

Closes #85 