### PR TITLE
Bugfix motor arm switch not working when dragged

### DIFF
--- a/src/AutoPilotPlugins/Common/MotorComponent.qml
+++ b/src/AutoPilotPlugins/Common/MotorComponent.qml
@@ -222,7 +222,7 @@ SetupPage {
                 spacing: ScreenTools.defaultFontPixelWidth
                 Switch {
                     id: safetySwitch
-                    onClicked: {
+                    onToggled: {
                         if (controller.vehicle.armed) {
                             timer.stop()
                         }

--- a/src/AutoPilotPlugins/Common/MotorComponent.qml
+++ b/src/AutoPilotPlugins/Common/MotorComponent.qml
@@ -8,7 +8,7 @@
  ****************************************************************************/
 
 import QtQuick          2.3
-import QtQuick.Controls 1.2
+import QtQuick.Controls 2.4
 import QtQuick.Dialogs  1.2
 
 import QGroundControl               1.0

--- a/src/AutoPilotPlugins/Common/MotorComponent.qml
+++ b/src/AutoPilotPlugins/Common/MotorComponent.qml
@@ -249,6 +249,7 @@ SetupPage {
                 }
 
                 QGCLabel {
+                    anchors.verticalCenter: safetySwitch.verticalCenter
                     color:  qgcPal.warningText
                     text:   qsTr("Slide this switch to arm the vehicle and enable the motor test (CAUTION!)")
                 }

--- a/src/AutoPilotPlugins/Common/MotorComponent.qml
+++ b/src/AutoPilotPlugins/Common/MotorComponent.qml
@@ -228,7 +228,6 @@ SetupPage {
                         }
 
                         controller.vehicle.armed = checked
-                        checked = controller.vehicle.armed // As crazy as this looks, it keeps things working the way they should see onArmedChanged below, that will take care of checked state
                     }
                 }
 


### PR DESCRIPTION
Upgrading QtQuick.controls to 2.4 allows it to work properly:
![deepin-screen-recorder_select area_20180918112713](https://user-images.githubusercontent.com/4013804/45695544-074f4b80-bb38-11e8-8ebf-56605823c5a8.gif)
Fix #204 