### PR TITLE
Revert "update gstreamer 1.5.2->1.14.0.1 on Windows"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,17 +19,17 @@ install:
   - mkdir %LOCALAPPDATA%\QtProject && copy test\qtlogging.ini %LOCALAPPDATA%\QtProject\
   - ps: |
       Write-Host "Installing GStreamer..." -ForegroundColor Cyan
-      $msiPath = "$($env:USERPROFILE)\gstreamer-1.0-x86-1.14.0.1.msi"
+      $msiPath = "$($env:USERPROFILE)\gstreamer-1.0-x86-1.5.2.msi"
       Write-Host "Downloading..."
-      (New-Object Net.WebClient).DownloadFile('https://gstreamer.freedesktop.org/data/pkg/windows/1.14.0.1/gstreamer-1.0-x86-1.14.0.1.msi', $msiPath)
+      (New-Object Net.WebClient).DownloadFile('https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/gstreamer-1.0-x86-1.5.2.msi', $msiPath)
       Write-Host "Installing..."
       cmd /c start /wait msiexec /package $msiPath /passive ADDLOCAL=ALL
       Write-Host "Installed" -ForegroundColor Green
   - ps: |
       Write-Host "Installing GStreamer dev..." -ForegroundColor Cyan
-      $msiPath = "$($env:USERPROFILE)\gstreamer-1.0-devel-x86-1.14.0.1.msi"
+      $msiPath = "$($env:USERPROFILE)\gstreamer-1.0-devel-x86-1.5.2.msi"
       Write-Host "Downloading..."
-      (New-Object Net.WebClient).DownloadFile('https://gstreamer.freedesktop.org/data/pkg/windows/1.14.0.1/gstreamer-1.0-devel-x86-1.14.0.1.msi', $msiPath)
+      (New-Object Net.WebClient).DownloadFile('https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/gstreamer-1.0-devel-x86-1.5.2.msi', $msiPath)
       Write-Host "Installing..."
       cmd /c start /wait msiexec /package $msiPath /passive ADDLOCAL=ALL
       Write-Host "Installed" -ForegroundColor Green


### PR DESCRIPTION
This reverts commit 8bb85de411c96c77052680e78f9fd88483755f79.
Although it feels like going backwards, going back to 1.5.2 makes us closer to upstream.

Fix #194 