### PR TITLE
MotorComponent.qml: re-introduce line matching switch to vehicle's armed state

### DIFF
--- a/src/AutoPilotPlugins/Common/MotorComponent.qml
+++ b/src/AutoPilotPlugins/Common/MotorComponent.qml
@@ -228,6 +228,7 @@ SetupPage {
                         }
 
                         controller.vehicle.armed = checked
+                        checked = controller.vehicle.armed  // This makes sure the switch matches the vehicle's state in case it refuses the command
                     }
                 }
 


### PR DESCRIPTION
This line makes sure the switch state matches the vehicle's armed state.
The line was mistakenly removed in https://github.com/bluerobotics/qgroundcontrol/pull/205